### PR TITLE
Add divisive k-means clustering and benchmark tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,6 @@ MESSAGE(STATUS "Compiling with flags:${CMAKE_CXX_FLAGS}")
 include_directories(include)
 
 add_executable(cluster tools/cluster.cpp)
+add_executable(bench tools/bench.cpp)
+target_link_libraries(bench PRIVATE pthread)
+target_link_libraries(cluster PRIVATE pthread)

--- a/include/kmeans.hpp
+++ b/include/kmeans.hpp
@@ -36,41 +36,60 @@ float_type distance_squared(std::vector<T> const& x, std::vector<Q> const& y) {
 float_type distance(mean const& x, mean const& y) { return std::sqrt(distance_squared(x, y)); }
 
 /*
-    Calculate the smallest distance between each of the data points and any of the input means.
+    Compute the squared distance from each point to a single mean, in parallel.
 */
 template <typename RandomAccessIterator>
-std::vector<float_type> closest_distance(std::vector<mean> const& means, RandomAccessIterator begin,
-                                         RandomAccessIterator end, thread_pool& threads) {
+std::vector<float_type> distances_to_mean(mean const& m, RandomAccessIterator begin,
+                                          RandomAccessIterator end, thread_pool& threads) {
     assert(end > begin);
     const uint64_t num_points = end - begin;
     const uint64_t num_threads = threads.num_threads();
-    std::vector<float_type> distances;
-    distances.resize(num_points);
+    std::vector<float_type> distances(num_points);
 
-    auto worker = [&](uint64_t start, uint64_t end) {
-        for (uint64_t i = start; i != end; ++i) {
-            auto const& point = *(begin + i);
-            float_type closest = distance_squared(point, means.front());
-            for (auto const& mean : means) {
-                float_type distance = distance_squared(point, mean);
-                if (distance < closest) closest = distance;
-            }
-            distances[i] = closest;
+    auto worker = [&](uint64_t start, uint64_t stop) {
+        for (uint64_t i = start; i != stop; ++i) {
+            distances[i] = distance_squared(*(begin + i), m);
         }
     };
 
     const uint64_t block_size = (num_points + num_threads - 1) / num_threads;
     for (uint64_t t = 0; t != num_threads; ++t) {
         uint64_t start = t * block_size;
-        uint64_t end = std::min(start + block_size, num_points);
-        if (start < end) {  // avoid empty range
-            threads.enqueue([&, start, end] { worker(start, end); });
-        }
+        uint64_t stop = std::min(start + block_size, num_points);
+        if (start < stop) threads.enqueue([&, start, stop] { worker(start, stop); });
     }
-
     threads.wait();
-
     return distances;
+}
+
+/*
+    For each point, update its stored "distance to closest mean so far" by
+    taking the min with its squared distance to a newly added mean.
+    Used by k-means++ to avoid recomputing distances to every prior mean.
+*/
+template <typename RandomAccessIterator>
+void update_min_distances(std::vector<float_type>& distances, mean const& new_mean,
+                          RandomAccessIterator begin, RandomAccessIterator end,
+                          thread_pool& threads) {
+    assert(end > begin);
+    const uint64_t num_points = end - begin;
+    assert(distances.size() == num_points);
+    const uint64_t num_threads = threads.num_threads();
+
+    auto worker = [&](uint64_t start, uint64_t stop) {
+        for (uint64_t i = start; i != stop; ++i) {
+            float_type d = distance_squared(*(begin + i), new_mean);
+            if (d < distances[i]) distances[i] = d;
+        }
+    };
+
+    const uint64_t block_size = (num_points + num_threads - 1) / num_threads;
+    for (uint64_t t = 0; t != num_threads; ++t) {
+        uint64_t start = t * block_size;
+        uint64_t stop = std::min(start + block_size, num_points);
+        if (start < stop) threads.enqueue([&, start, stop] { worker(start, stop); });
+    }
+    threads.wait();
 }
 
 /*
@@ -108,16 +127,25 @@ std::vector<mean> random_plusplus(RandomAccessIterator begin, RandomAccessIterat
         means.push_back(m);
     }
 
+    /*
+        Maintain a running vector of squared distances from each point to its
+        closest mean so far. After adding a new mean we only need to compare
+        against that one mean, dropping init from O(N*k^2*d) to O(N*k*d).
+    */
+    auto distances = details::distances_to_mean(means.front(), begin, end, threads);
+
     for (uint32_t i = 1; i != k; ++i) {
-        /* Calculate the distance to the closest mean for each data point */
-        auto distances = details::closest_distance(means, begin, end, threads);
-        /* Pick a random point weighted by the distance from existing means */
+        /* Pick a random point weighted by squared distance from existing means */
         std::discrete_distribution<uint64_t> generator(distances.begin(), distances.end());
         uint64_t index = generator(rand_engine);
         m.clear();
         auto const& point = *(begin + index);
         for (auto x : point) m.push_back(float_type(x));
         means.push_back(m);
+
+        if (i + 1 != k) {
+            details::update_min_distances(distances, means.back(), begin, end, threads);
+        }
     }
 
     return means;

--- a/include/kmeans.hpp
+++ b/include/kmeans.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
 #include <cassert>
+#include <cmath>
+#include <queue>
 #include <random>
 #include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 #include "thread_pool.hpp"
 

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <vector>
 #include <queue>
 #include <thread>

--- a/tools/bench.cpp
+++ b/tools/bench.cpp
@@ -6,7 +6,7 @@
     to "discover" those K clusters. Reports wall-clock time, the number
     of clusters actually found, total iterations and final MSE.
 
-    Usage: bench N threads K [d] [sigma] [seed]
+    Usage: bench N d K threads [sigma] [seed]
 */
 
 #include <chrono>
@@ -92,21 +92,22 @@ static double compute_mse(std::vector<point> const& points,
 }
 
 static void usage(const char* prog) {
-    std::cerr << "usage: " << prog << " N threads K [d=64] [sigma=15] [seed=42]\n"
+    std::cerr << "usage: " << prog << " N d K threads [sigma=15] [seed=42]\n"
               << "  N        number of points\n"
-              << "  threads  number of worker threads\n"
-              << "  K        target number of clusters (also # of true gaussian centers)\n";
+              << "  d        size (dimension) of each point vector\n"
+              << "  K        target number of clusters (also # of true gaussian centers)\n"
+              << "  threads  number of worker threads\n";
 }
 
 int main(int argc, char** argv) {
-    if (argc < 4) {
+    if (argc < 5) {
         usage(argv[0]);
         return 1;
     }
     const uint64_t N = std::strtoull(argv[1], nullptr, 10);
-    const uint64_t num_threads = std::strtoull(argv[2], nullptr, 10);
+    const uint64_t d = std::strtoull(argv[2], nullptr, 10);
     const uint64_t K = std::strtoull(argv[3], nullptr, 10);
-    const uint64_t d = (argc > 4) ? std::strtoull(argv[4], nullptr, 10) : 64;
+    const uint64_t num_threads = std::strtoull(argv[4], nullptr, 10);
     const double sigma = (argc > 5) ? std::strtod(argv[5], nullptr) : 15.0;
     const uint64_t seed = (argc > 6) ? std::strtoull(argv[6], nullptr, 10) : 42;
 

--- a/tools/bench.cpp
+++ b/tools/bench.cpp
@@ -1,0 +1,213 @@
+/*
+    Benchmark for kmeans Lloyd's algorithm on synthetic data.
+
+    Reports per-phase timings (kmeans++ init, calculate_clusters,
+    calculate_means) plus total time, final MSE, and iteration count
+    so we can compare optimizations without changing solution quality.
+*/
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "../include/kmeans.hpp"
+
+using namespace kmeans;
+
+using clock_type = std::chrono::steady_clock;
+
+static double seconds_since(clock_type::time_point t0) {
+    auto t1 = clock_type::now();
+    return std::chrono::duration<double>(t1 - t0).count();
+}
+
+/*
+    Generate N uint8 points of dimension d, drawn from G isotropic Gaussian
+    centers placed at random uint8 means. Values are clamped to [0,255].
+*/
+static std::vector<point> generate_synthetic(uint64_t N, uint64_t d, uint64_t G,
+                                             double sigma, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<int> center_dist(0, 255);
+    std::vector<std::vector<uint8_t>> centers(G, std::vector<uint8_t>(d));
+    for (uint64_t g = 0; g != G; ++g) {
+        for (uint64_t j = 0; j != d; ++j) centers[g][j] = uint8_t(center_dist(rng));
+    }
+    std::normal_distribution<double> noise(0.0, sigma);
+    std::uniform_int_distribution<uint64_t> assign(0, G - 1);
+    std::vector<point> points(N, point(d));
+    for (uint64_t i = 0; i != N; ++i) {
+        uint64_t g = assign(rng);
+        auto const& c = centers[g];
+        for (uint64_t j = 0; j != d; ++j) {
+            double v = double(c[j]) + noise(rng);
+            if (v < 0) v = 0;
+            if (v > 255) v = 255;
+            points[i][j] = uint8_t(v);
+        }
+    }
+    return points;
+}
+
+/*
+    Compute total within-cluster sum of squared distances divided by N.
+*/
+static double compute_mse(std::vector<point> const& points,
+                          std::vector<uint32_t> const& clusters,
+                          std::vector<mean> const& means) {
+    double sse = 0.0;
+    for (uint64_t i = 0; i != points.size(); ++i) {
+        sse += details::distance_squared(points[i], means[clusters[i]]);
+    }
+    return sse / points.size();
+}
+
+struct phase_times {
+    double init = 0;
+    double assign = 0;  // calculate_clusters
+    double update = 0;  // calculate_means
+    double total = 0;
+    uint64_t iters = 0;
+    double mse = 0;
+};
+
+/*
+    Re-implements kmeans_lloyd with per-phase timing so we can attribute
+    cost. Behaviour matches kmeans.hpp's kmeans_lloyd: kmeans++ init,
+    then alternate calculate_clusters / calculate_means until max_iter
+    or min_delta.
+*/
+static phase_times run_lloyd_timed(std::vector<point> const& points, uint32_t k,
+                                   uint64_t max_iter, float_type min_delta,
+                                   uint64_t seed, uint64_t num_threads) {
+    phase_times pt;
+    thread_pool threads(num_threads);
+
+    auto t_total = clock_type::now();
+
+    auto t0 = clock_type::now();
+    auto means = details::random_plusplus(points.begin(), points.end(), k, seed, threads);
+    pt.init = seconds_since(t0);
+
+    std::vector<uint32_t> clusters;
+    std::vector<mean> old_means;
+
+    for (uint64_t it = 0; it != max_iter; ++it) {
+        auto t1 = clock_type::now();
+        clusters = details::calculate_clusters(points.begin(), points.end(), means, threads);
+        pt.assign += seconds_since(t1);
+
+        auto t2 = clock_type::now();
+        old_means = std::move(means);
+        means = details::calculate_means(points.begin(), points.end(), clusters, old_means, k);
+        pt.update += seconds_since(t2);
+
+        pt.iters += 1;
+
+        if (min_delta > 0) {
+            auto deltas = details::deltas(old_means, means);
+            if (details::deltas_below_limit(deltas, min_delta)) break;
+        }
+    }
+
+    pt.total = seconds_since(t_total);
+    pt.mse = compute_mse(points, clusters, means);
+    return pt;
+}
+
+static void print_header() {
+    std::cout << "N,d,k,threads,iters,init_s,assign_s,update_s,total_s,mse\n";
+}
+
+static void print_row(uint64_t N, uint64_t d, uint32_t k, uint64_t threads, phase_times const& pt) {
+    std::cout << N << ',' << d << ',' << k << ',' << threads << ',' << pt.iters << ','
+              << std::fixed << std::setprecision(4) << pt.init << ',' << pt.assign << ','
+              << pt.update << ',' << pt.total << ',' << std::setprecision(2) << pt.mse << '\n'
+              << std::flush;
+}
+
+int main(int argc, char** argv) {
+    /* Defaults: a small grid that runs in ~a minute on a 4-core box. */
+    std::vector<uint64_t> Ns = {10000, 100000};
+    std::vector<uint64_t> ds = {16, 64};
+    std::vector<uint32_t> ks = {16, 64};
+    std::vector<uint64_t> ts = {1, 4};
+    uint64_t max_iter = 20;
+    uint64_t G = 32;     // number of true gaussian centers in the data
+    double sigma = 20.0; // per-dim stddev of the gaussian noise
+    uint64_t seed = 42;
+    int repeats = 1;
+
+    /* Optional argv override: bench [grid|big|huge] [repeats] */
+    if (argc >= 2) {
+        std::string mode = argv[1];
+        if (mode == "big") {
+            Ns = {100000, 1000000};
+            ds = {16, 64, 128};
+            ks = {16, 64, 256};
+            ts = {1, 4};
+            max_iter = 20;
+        } else if (mode == "huge") {
+            Ns = {1000000};
+            ds = {128};
+            ks = {256, 1024};
+            ts = {1, 4};
+            max_iter = 10;
+        } else if (mode == "small") {
+            Ns = {10000};
+            ds = {16};
+            ks = {16};
+            ts = {1};
+            max_iter = 10;
+        }
+    }
+    if (argc >= 3) repeats = std::atoi(argv[2]);
+    if (repeats < 1) repeats = 1;
+
+    std::cerr << "bench: repeats=" << repeats << " max_iter=" << max_iter
+              << " G=" << G << " sigma=" << sigma << "\n";
+
+    print_header();
+
+    for (uint64_t N : Ns) {
+        for (uint64_t d : ds) {
+            std::cerr << "generating N=" << N << " d=" << d << " ..." << std::flush;
+            auto t_gen = clock_type::now();
+            auto points = generate_synthetic(N, d, G, sigma, seed);
+            std::cerr << " done in " << seconds_since(t_gen) << "s\n";
+
+            for (uint32_t k : ks) {
+                if (k > N) continue;
+                for (uint64_t nt : ts) {
+                    /* Average phase times over `repeats` runs. Sum then divide. */
+                    phase_times agg;
+                    for (int r = 0; r != repeats; ++r) {
+                        auto pt = run_lloyd_timed(points, k, max_iter, /*min_delta*/ 0,
+                                                  seed + r, nt);
+                        agg.init += pt.init;
+                        agg.assign += pt.assign;
+                        agg.update += pt.update;
+                        agg.total += pt.total;
+                        agg.iters += pt.iters;
+                        agg.mse += pt.mse;
+                    }
+                    agg.init /= repeats;
+                    agg.assign /= repeats;
+                    agg.update /= repeats;
+                    agg.total /= repeats;
+                    agg.iters /= repeats;
+                    agg.mse /= repeats;
+                    print_row(N, d, k, nt, agg);
+                }
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tools/bench.cpp
+++ b/tools/bench.cpp
@@ -1,15 +1,17 @@
 /*
-    Benchmark for kmeans Lloyd's algorithm on synthetic data.
+    Benchmark for kmeans_divisive on synthetic data.
 
-    Reports per-phase timings (kmeans++ init, calculate_clusters,
-    calculate_means) plus total time, final MSE, and iteration count
-    so we can compare optimizations without changing solution quality.
+    Generates N uint8 points drawn from K isotropic gaussian centers and
+    runs the bisective algorithm with min_cluster_size = N/K so it tries
+    to "discover" those K clusters. Reports wall-clock time, the number
+    of clusters actually found, total iterations and final MSE.
+
+    Usage: bench N threads K [d] [sigma] [seed]
 */
 
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
-#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <random>
@@ -23,16 +25,16 @@ using namespace kmeans;
 using clock_type = std::chrono::steady_clock;
 
 static double seconds_since(clock_type::time_point t0) {
-    auto t1 = clock_type::now();
-    return std::chrono::duration<double>(t1 - t0).count();
+    return std::chrono::duration<double>(clock_type::now() - t0).count();
 }
 
 /*
-    Generate N uint8 points of dimension d, drawn from G isotropic Gaussian
-    centers placed at random uint8 means. Values are clamped to [0,255].
+    Generate N uint8 points of dimension d, drawn from G isotropic gaussian
+    centers placed at random uint8 positions. Values are clamped to [0,255].
+    Returns the points and the ground-truth assignments (point i -> center).
 */
-static std::vector<point> generate_synthetic(uint64_t N, uint64_t d, uint64_t G,
-                                             double sigma, uint64_t seed) {
+static std::pair<std::vector<point>, std::vector<uint32_t>>
+generate_synthetic(uint64_t N, uint64_t d, uint64_t G, double sigma, uint64_t seed) {
     std::mt19937_64 rng(seed);
     std::uniform_int_distribution<int> center_dist(0, 255);
     std::vector<std::vector<uint8_t>> centers(G, std::vector<uint8_t>(d));
@@ -42,8 +44,10 @@ static std::vector<point> generate_synthetic(uint64_t N, uint64_t d, uint64_t G,
     std::normal_distribution<double> noise(0.0, sigma);
     std::uniform_int_distribution<uint64_t> assign(0, G - 1);
     std::vector<point> points(N, point(d));
+    std::vector<uint32_t> truth(N);
     for (uint64_t i = 0; i != N; ++i) {
         uint64_t g = assign(rng);
+        truth[i] = uint32_t(g);
         auto const& c = centers[g];
         for (uint64_t j = 0; j != d; ++j) {
             double v = double(c[j]) + noise(rng);
@@ -52,162 +56,104 @@ static std::vector<point> generate_synthetic(uint64_t N, uint64_t d, uint64_t G,
             points[i][j] = uint8_t(v);
         }
     }
-    return points;
+    return {std::move(points), std::move(truth)};
 }
 
 /*
-    Compute total within-cluster sum of squared distances divided by N.
+    Compute mean within-cluster squared distance from points to their
+    cluster's centroid.
 */
 static double compute_mse(std::vector<point> const& points,
                           std::vector<uint32_t> const& clusters,
-                          std::vector<mean> const& means) {
+                          uint64_t num_clusters) {
+    const uint64_t d = points.front().size();
+    std::vector<std::vector<double>> centroids(num_clusters, std::vector<double>(d, 0.0));
+    std::vector<uint64_t> counts(num_clusters, 0);
+    for (uint64_t i = 0; i != points.size(); ++i) {
+        uint32_t c = clusters[i];
+        counts[c] += 1;
+        for (uint64_t j = 0; j != d; ++j) centroids[c][j] += double(points[i][j]);
+    }
+    for (uint64_t c = 0; c != num_clusters; ++c) {
+        if (counts[c] == 0) continue;
+        for (uint64_t j = 0; j != d; ++j) centroids[c][j] /= counts[c];
+    }
     double sse = 0.0;
     for (uint64_t i = 0; i != points.size(); ++i) {
-        sse += details::distance_squared(points[i], means[clusters[i]]);
+        uint32_t c = clusters[i];
+        double s = 0.0;
+        for (uint64_t j = 0; j != d; ++j) {
+            double delta = double(points[i][j]) - centroids[c][j];
+            s += delta * delta;
+        }
+        sse += s;
     }
     return sse / points.size();
 }
 
-struct phase_times {
-    double init = 0;
-    double assign = 0;  // calculate_clusters
-    double update = 0;  // calculate_means
-    double total = 0;
-    uint64_t iters = 0;
-    double mse = 0;
-};
-
-/*
-    Re-implements kmeans_lloyd with per-phase timing so we can attribute
-    cost. Behaviour matches kmeans.hpp's kmeans_lloyd: kmeans++ init,
-    then alternate calculate_clusters / calculate_means until max_iter
-    or min_delta.
-*/
-static phase_times run_lloyd_timed(std::vector<point> const& points, uint32_t k,
-                                   uint64_t max_iter, float_type min_delta,
-                                   uint64_t seed, uint64_t num_threads) {
-    phase_times pt;
-    thread_pool threads(num_threads);
-
-    auto t_total = clock_type::now();
-
-    auto t0 = clock_type::now();
-    auto means = details::random_plusplus(points.begin(), points.end(), k, seed, threads);
-    pt.init = seconds_since(t0);
-
-    std::vector<uint32_t> clusters;
-    std::vector<mean> old_means;
-
-    for (uint64_t it = 0; it != max_iter; ++it) {
-        auto t1 = clock_type::now();
-        clusters = details::calculate_clusters(points.begin(), points.end(), means, threads);
-        pt.assign += seconds_since(t1);
-
-        auto t2 = clock_type::now();
-        old_means = std::move(means);
-        means = details::calculate_means(points.begin(), points.end(), clusters, old_means, k);
-        pt.update += seconds_since(t2);
-
-        pt.iters += 1;
-
-        if (min_delta > 0) {
-            auto deltas = details::deltas(old_means, means);
-            if (details::deltas_below_limit(deltas, min_delta)) break;
-        }
-    }
-
-    pt.total = seconds_since(t_total);
-    pt.mse = compute_mse(points, clusters, means);
-    return pt;
-}
-
-static void print_header() {
-    std::cout << "N,d,k,threads,iters,init_s,assign_s,update_s,total_s,mse\n";
-}
-
-static void print_row(uint64_t N, uint64_t d, uint32_t k, uint64_t threads, phase_times const& pt) {
-    std::cout << N << ',' << d << ',' << k << ',' << threads << ',' << pt.iters << ','
-              << std::fixed << std::setprecision(4) << pt.init << ',' << pt.assign << ','
-              << pt.update << ',' << pt.total << ',' << std::setprecision(2) << pt.mse << '\n'
-              << std::flush;
+static void usage(const char* prog) {
+    std::cerr << "usage: " << prog << " N threads K [d=64] [sigma=15] [seed=42]\n"
+              << "  N        number of points\n"
+              << "  threads  number of worker threads\n"
+              << "  K        target number of clusters (also # of true gaussian centers)\n";
 }
 
 int main(int argc, char** argv) {
-    /* Defaults: a small grid that runs in ~a minute on a 4-core box. */
-    std::vector<uint64_t> Ns = {10000, 100000};
-    std::vector<uint64_t> ds = {16, 64};
-    std::vector<uint32_t> ks = {16, 64};
-    std::vector<uint64_t> ts = {1, 4};
-    uint64_t max_iter = 20;
-    uint64_t G = 32;     // number of true gaussian centers in the data
-    double sigma = 20.0; // per-dim stddev of the gaussian noise
-    uint64_t seed = 42;
-    int repeats = 1;
-
-    /* Optional argv override: bench [grid|big|huge] [repeats] */
-    if (argc >= 2) {
-        std::string mode = argv[1];
-        if (mode == "big") {
-            Ns = {100000, 1000000};
-            ds = {16, 64, 128};
-            ks = {16, 64, 256};
-            ts = {1, 4};
-            max_iter = 20;
-        } else if (mode == "huge") {
-            Ns = {1000000};
-            ds = {128};
-            ks = {256, 1024};
-            ts = {1, 4};
-            max_iter = 10;
-        } else if (mode == "small") {
-            Ns = {10000};
-            ds = {16};
-            ks = {16};
-            ts = {1};
-            max_iter = 10;
-        }
+    if (argc < 4) {
+        usage(argv[0]);
+        return 1;
     }
-    if (argc >= 3) repeats = std::atoi(argv[2]);
-    if (repeats < 1) repeats = 1;
+    const uint64_t N = std::strtoull(argv[1], nullptr, 10);
+    const uint64_t num_threads = std::strtoull(argv[2], nullptr, 10);
+    const uint64_t K = std::strtoull(argv[3], nullptr, 10);
+    const uint64_t d = (argc > 4) ? std::strtoull(argv[4], nullptr, 10) : 64;
+    const double sigma = (argc > 5) ? std::strtod(argv[5], nullptr) : 15.0;
+    const uint64_t seed = (argc > 6) ? std::strtoull(argv[6], nullptr, 10) : 42;
 
-    std::cerr << "bench: repeats=" << repeats << " max_iter=" << max_iter
-              << " G=" << G << " sigma=" << sigma << "\n";
-
-    print_header();
-
-    for (uint64_t N : Ns) {
-        for (uint64_t d : ds) {
-            std::cerr << "generating N=" << N << " d=" << d << " ..." << std::flush;
-            auto t_gen = clock_type::now();
-            auto points = generate_synthetic(N, d, G, sigma, seed);
-            std::cerr << " done in " << seconds_since(t_gen) << "s\n";
-
-            for (uint32_t k : ks) {
-                if (k > N) continue;
-                for (uint64_t nt : ts) {
-                    /* Average phase times over `repeats` runs. Sum then divide. */
-                    phase_times agg;
-                    for (int r = 0; r != repeats; ++r) {
-                        auto pt = run_lloyd_timed(points, k, max_iter, /*min_delta*/ 0,
-                                                  seed + r, nt);
-                        agg.init += pt.init;
-                        agg.assign += pt.assign;
-                        agg.update += pt.update;
-                        agg.total += pt.total;
-                        agg.iters += pt.iters;
-                        agg.mse += pt.mse;
-                    }
-                    agg.init /= repeats;
-                    agg.assign /= repeats;
-                    agg.update /= repeats;
-                    agg.total /= repeats;
-                    agg.iters /= repeats;
-                    agg.mse /= repeats;
-                    print_row(N, d, k, nt, agg);
-                }
-            }
-        }
+    if (N == 0 || num_threads == 0 || K == 0 || d == 0) {
+        usage(argv[0]);
+        return 1;
     }
+    if (K > N) {
+        std::cerr << "error: K (" << K << ") cannot exceed N (" << N << ")\n";
+        return 1;
+    }
+
+    std::cerr << "config: N=" << N << " d=" << d << " K=" << K
+              << " threads=" << num_threads << " sigma=" << sigma << " seed=" << seed << "\n";
+
+    std::cerr << "generating synthetic data ... " << std::flush;
+    auto t_gen = clock_type::now();
+    auto [points, truth] = generate_synthetic(N, d, K, sigma, seed);
+    (void)truth;
+    std::cerr << "done in " << seconds_since(t_gen) << "s\n";
+
+    /*
+        Set min_cluster_size = N/K so binary splits stop at roughly K leaves.
+        min_mse is left unset; kmeans_divisive auto-derives it from the root
+        cluster's MSE on the first iteration.
+    */
+    clustering_parameters params;
+    params.set_num_threads(num_threads);
+    params.set_random_seed(seed);
+    params.set_max_iteration(20);
+    params.set_min_cluster_size(std::max<uint64_t>(1, N / K));
+
+    std::cerr << "running kmeans_divisive (min_cluster_size=" << (N / K) << ") ... " << std::flush;
+    auto t_run = clock_type::now();
+    auto data = kmeans_divisive(points.begin(), points.end(), params);
+    double total_s = seconds_since(t_run);
+    std::cerr << "done in " << total_s << "s\n";
+
+    double mse = compute_mse(points, data.clusters, data.num_clusters);
+
+    std::cout << std::fixed << std::setprecision(4);
+    std::cout << "N=" << N << " d=" << d << " target_K=" << K
+              << " threads=" << num_threads << "\n"
+              << "  found_clusters = " << data.num_clusters << "\n"
+              << "  iterations     = " << data.iterations << "\n"
+              << "  total_time_s   = " << total_s << "\n"
+              << "  mse            = " << std::setprecision(2) << mse << "\n";
 
     return 0;
 }


### PR DESCRIPTION
## Summary
This PR adds a divisive (bisecting) k-means clustering algorithm and a comprehensive benchmark tool for evaluating its performance on synthetic data.

## Key Changes

- **New divisive k-means implementation** (`kmeans_divisive`): A top-down clustering approach that recursively bisects clusters until reaching a target minimum cluster size, providing an alternative to the existing k-means algorithm.

- **Benchmark tool** (`tools/bench.cpp`): A new command-line utility that:
  - Generates synthetic data from K isotropic Gaussian centers
  - Runs the divisive k-means algorithm with configurable parameters
  - Reports performance metrics: wall-clock time, number of clusters found, iterations, and final MSE
  - Supports multi-threaded execution

- **Optimized k-means++ initialization**: Improved the initialization algorithm to avoid redundant distance calculations:
  - Replaced `closest_distance()` with `distances_to_mean()` for computing distances to a single mean
  - Added `update_min_distances()` to incrementally update minimum distances when adding new means
  - Reduces complexity from O(N·k²·d) to O(N·k·d)

- **Build system updates**: Added CMake targets for the new benchmark executable with pthread linking

## Implementation Details

- The benchmark generates uint8 points in configurable dimensions with Gaussian noise around random centers
- The divisive algorithm uses `min_cluster_size = N/K` to naturally discover approximately K clusters
- Distance calculations are parallelized across worker threads for both the main algorithm and initialization
- The k-means++ optimization maintains a running vector of squared distances, updating only against newly added means rather than recomputing against all prior means

https://claude.ai/code/session_01BPW124WnxaJ27qPycmZ96p